### PR TITLE
Fix example in the usage section

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -121,7 +121,7 @@ If you doesn't see scrollbar show, please open `dev-tool` to checkout whether yo
         ops: {
           vuescroll: {},
           scrollPanel: {},
-          rail: {}
+          rail: {},
           bar: {}
         }
       }


### PR DESCRIPTION
Add the missing comma between rail and bar properties in the ops: {}.